### PR TITLE
Feature/jsm-notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,20 @@ prefix: `consul-alerts/config/notifiers/opsgenie/`
 | cluster-name | The name of the cluster. [Default: "Consul Alerts"] |
 | api-key      | API Key                              (mandatory)    |
 
+#### JSM
+
+To enable JSM built-in notifier, set
+`consul-alerts/config/notifiers/jsm/enabled` to `true`. JSM details
+needs to be configured.
+
+prefix: `consul-alerts/config/notifiers/jsm/`
+
+| key          | description                                         |
+|--------------|-----------------------------------------------------|
+| enabled      | Enable the JSM notifier. [Default: false]           |
+| cluster-name | The name of the cluster. [Default: "Consul Alerts"] |
+| api-key      | API Key                              (mandatory)    |
+
 #### Amazon Web Services Simple Notification Service ("SNS")
 
 To enable AWS SNS built-in notifier, set

--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -247,6 +247,7 @@ func builtinNotifiers() map[string]notifier.Notifier {
 	pagerdutyNotifier := consulClient.PagerDutyNotifier()
 	hipchatNotifier := consulClient.HipChatNotifier()
 	opsgenieNotifier := consulClient.OpsGenieNotifier()
+	jsmNotifier := consulClient.JSMNotifier()
 	awssnsNotifier := consulClient.AwsSnsNotifier()
 	victoropsNotifier := consulClient.VictorOpsNotifier()
 	httpEndpointNotifier := consulClient.HttpEndpointNotifier()
@@ -279,6 +280,9 @@ func builtinNotifiers() map[string]notifier.Notifier {
 	}
 	if opsgenieNotifier.Enabled {
 		notifiers[opsgenieNotifier.NotifierName()] = opsgenieNotifier
+	}
+	if jsmNotifier.Enabled {
+		notifiers[jsmNotifier.NotifierName()] = jsmNotifier
 	}
 	if awssnsNotifier.Enabled {
 		notifiers[awssnsNotifier.NotifierName()] = awssnsNotifier

--- a/consul/client.go
+++ b/consul/client.go
@@ -221,6 +221,14 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/opsgenie/api-key":
 				valErr = loadCustomValue(&config.Notifiers.OpsGenie.ApiKey, val, ConfigTypeString)
 
+				// JSM notifier config
+			case "consul-alerts/config/notifiers/jsm/enabled":
+				valErr = loadCustomValue(&config.Notifiers.JSM.Enabled, val, ConfigTypeBool)
+			case "consul-alerts/config/notifiers/jsm/cluster-name":
+				valErr = loadCustomValue(&config.Notifiers.JSM.ClusterName, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/jsm/api-key":
+				valErr = loadCustomValue(&config.Notifiers.JSM.ApiKey, val, ConfigTypeString)
+
 				// AwsSns notifier config
 			case "consul-alerts/config/notifiers/awssns/cluster-name":
 				valErr = loadCustomValue(&config.Notifiers.AwsSns.ClusterName, val, ConfigTypeString)

--- a/consul/interface.go
+++ b/consul/interface.go
@@ -78,6 +78,7 @@ type Consul interface {
 	PagerDutyNotifier() *notifier.PagerDutyNotifier
 	HipChatNotifier() *notifier.HipChatNotifier
 	OpsGenieNotifier() *notifier.OpsGenieNotifier
+	JSMNotifier() *notifier.JSMNotifier
 	AwsSnsNotifier() *notifier.AwsSnsNotifier
 	VictorOpsNotifier() *notifier.VictorOpsNotifier
 	HttpEndpointNotifier() *notifier.HttpEndpointNotifier
@@ -161,6 +162,11 @@ func DefaultAlertConfig() *ConsulAlertConfig {
 		ClusterName: "Consul-Alerts",
 	}
 
+	jsm := &notifier.JSMNotifier{
+		Enabled:     false,
+		ClusterName: "Consul-Alerts",
+	}
+
 	awsSns := &notifier.AwsSnsNotifier{
 		Enabled:     false,
 		ClusterName: "Consul-Alerts",
@@ -190,6 +196,7 @@ func DefaultAlertConfig() *ConsulAlertConfig {
 		PagerDuty:         pagerduty,
 		HipChat:           hipchat,
 		OpsGenie:          opsgenie,
+		JSM:               jsm,
 		AwsSns:            awsSns,
 		VictorOps:         victorOps,
 		HttpEndpoint:      httpEndpoint,

--- a/notifier/jsm-notifier
+++ b/notifier/jsm-notifier
@@ -1,0 +1,91 @@
+package notifier
+
+import (
+	"fmt"
+	log "github.com/AcalephStorage/consul-alerts/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+)
+
+type JSMNotifier struct {
+	Enabled     bool
+	ClusterName string `json:"cluster-name"`
+	ApiKey      string `json:"api-key"`
+}
+
+// NotifierName provides name for notifier selection
+func (jsm *JSMNotifier) NotifierName() string {
+	return "jsm"
+}
+
+func (jsm *JSMNotifier) Copy() Notifier {
+	notifier := *jsm
+	return &notifier
+}
+
+//Notify sends messages to the endpoint notifier
+func (jsm *JSMNotifier) Notify(messages Messages) bool {
+
+	overallStatus, pass, warn, fail := messages.Summary()
+
+	for _, message := range messages {
+		title := fmt.Sprintf("\n%s:%s:%s is %s.", message.Node, message.Service, message.Check, message.Status)
+		alias := jsm.createAlias(message)
+		content := fmt.Sprintf(header, jsm.ClusterName, overallStatus, fail, warn, pass)
+		content += fmt.Sprintf("\n%s:%s:%s is %s.", message.Node, message.Service, message.Check, message.Status)
+		content += fmt.Sprintf("\n%s", message.Output)
+
+		// create the alert
+		switch {
+		case message.IsCritical():
+		case message.IsWarning():
+		case message.IsPassing():
+			ok = jsm.sendAlertRequest(title, message.Status, content, alias) && ok
+		default:
+			ok = false
+			log.Warn("Message was not either IsCritical, IsWarning or IsPasssing. No notification was sent for ", alias)
+		}
+	}
+	return ok
+}
+
+func (jsm JSMNotifier) createAlias(message Message) string {
+	incidentKey := message.Node
+	if message.ServiceId != "" {
+		incidentKey += ":" + message.ServiceId
+	}
+
+	return incidentKey
+}
+
+func (jsm *JSMNotifier) sendAlertRequest(title string, status string, content string, alias string) bool {
+	log.Debug(fmt.Sprintf("JSM alert alias: %s", alias))
+
+    requestBody := {
+        "message": title,
+        "alias": alias,
+        "description": content,
+        "details": {
+          "messageType": status
+        },
+        "sources": "consul",
+        "entity": jsm.ClusterName,
+    }
+
+    // notifier.BaseURL => https://api.atlassian.com
+    // notifier.Endpoint => /jsm/ops/integration/v2/alerts
+    endpoint := fmt.Sprintf("%s%s%s%s", notifier.BaseURL, notifier.Endpoint, "?apiKey=", JSM.ApiKey)
+    if res, err := http.Post(endpoint, "application/json", bytes.NewBuffer(requestBody)); err != nil {
+        log.Println("Unable to send data to JSM endpoint:", err)
+        return false
+    } else {
+        defer res.Body.Close()
+        statusCode := res.StatusCode
+        if statusCode != 200 {
+            body, _ := ioutil.ReadAll(res.Body)
+            log.Println("Unable to notify JSM endpoint:", string(body))
+            return false
+        } else {
+            log.Println("JSM notification sent.")
+            return true
+        }
+    }
+}

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -50,6 +50,7 @@ type Notifiers struct {
 	PagerDuty         *PagerDutyNotifier         `json:"pagerduty"`
 	HipChat           *HipChatNotifier           `json:"hipchat"`
 	OpsGenie          *OpsGenieNotifier          `json:"opsgenie"`
+    JSM               *JSMNotifier               `json:"jsm"`
 	AwsSns            *AwsSnsNotifier            `json:"awssns"`
 	VictorOps         *VictorOpsNotifier         `json:"victorops"`
 	HttpEndpoint      *HttpEndpointNotifier      `json:"http-endpoint"`
@@ -77,6 +78,8 @@ func (n Notifiers) GetNotifier(name string) (Notifier, bool) {
 		return n.PagerDuty, true
 	case n.OpsGenie != nil && n.OpsGenie.NotifierName() == name:
 		return n.OpsGenie, true
+	case n.JSM != nil && n.JSM.NotifierName() == name:
+		return n.JSM, true
 	case n.AwsSns != nil && n.AwsSns.NotifierName() == name:
 		return n.AwsSns, true
 	case n.VictorOps != nil && n.VictorOps.NotifierName() == name:

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -50,7 +50,7 @@ type Notifiers struct {
 	PagerDuty         *PagerDutyNotifier         `json:"pagerduty"`
 	HipChat           *HipChatNotifier           `json:"hipchat"`
 	OpsGenie          *OpsGenieNotifier          `json:"opsgenie"`
-    JSM               *JSMNotifier               `json:"jsm"`
+        JSM               *JSMNotifier               `json:"jsm"`
 	AwsSns            *AwsSnsNotifier            `json:"awssns"`
 	VictorOps         *VictorOpsNotifier         `json:"victorops"`
 	HttpEndpoint      *HttpEndpointNotifier      `json:"http-endpoint"`


### PR DESCRIPTION
In the scope of the Opsgenie-JSM consolidation, jsm-notifier is added.
https://ifountain.atlassian.net/browse/HEIMDALL-9595

```
Request URL: https://api.atlassian.com/jsm/ops/integration/v2/alerts/?apiKey=<API_KEY>
Request Method: POST
Request Body: 
{
  "message": <title>,
  "alias": <alias>,
  "description": <content>,
  "details": {
    "messageType": <message.status>
  },
  "sources": "consul",
  "entity": <jsm.ClusterName>,
}
``` 

❗**<message.status>** will be used in alert filter in order to determine if the event is create or close alert event.

<img width="723" alt="image" src="https://github.com/fusiondog/consul-alerts/assets/106143372/658fe94d-464e-4b3e-a4f7-e4c2db9e871a">
